### PR TITLE
Additional Immortuos Calyx Compat Features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,10 @@ minecraft {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.17.1-37.0.8'
-    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
-    //runtimeOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+    minecraft 'net.minecraftforge:forge:1.17.1-37.0.13'
+    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+//    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+//    runtimeOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,9 @@ minecraft {
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.17.1-37.0.13'
-    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
-//    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+    //Implementation allows you to have both the in code references, and load the mod in game for testing!
+//    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 //    runtimeOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 }
 

--- a/src/main/java/com/dicemc/corruptedlands/Config.java
+++ b/src/main/java/com/dicemc/corruptedlands/Config.java
@@ -14,6 +14,7 @@ public class Config {
 	public static ForgeConfigSpec.ConfigValue<Integer> PURIFIER_RECHARGE_RATE;
 	public static ForgeConfigSpec.ConfigValue<Integer> PURIFIER_DRAIN_RATE;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_EFFECT_LEVEL;
+	public static ForgeConfigSpec.ConfigValue<Boolean> CALYX_EGGS_CORRUPT_LAND;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_STRENGTHEN_INFECTED;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_RESISTANCE_INFECTED;
 	public static ForgeConfigSpec.ConfigValue<Float> CORRUPTION_EFFECT_POWER;
@@ -49,6 +50,8 @@ public class Config {
 						.defineInRange("Calyx_Strength", 1, 0, 5);
 		CALYX_RESISTANCE_INFECTED = SERVER_BUILDER.comment("Resistance Effect level of entities Heavily Infected with Immortuos on corrupted land")
 						.defineInRange("Calyx_Resistance", 1, 0, 5);
+		CALYX_EGGS_CORRUPT_LAND = SERVER_BUILDER.comment("Whether or not Immortuos Calyx eggs will corrupt land along with rotten flesh.")
+						.define("Calyx_Eggs_Corrupt", true);
 		SERVER_BUILDER.pop();
 		
 		COMMON_BUILDER.comment("Compat Settings").push("Compat");

--- a/src/main/java/com/dicemc/corruptedlands/Config.java
+++ b/src/main/java/com/dicemc/corruptedlands/Config.java
@@ -14,6 +14,8 @@ public class Config {
 	public static ForgeConfigSpec.ConfigValue<Integer> PURIFIER_RECHARGE_RATE;
 	public static ForgeConfigSpec.ConfigValue<Integer> PURIFIER_DRAIN_RATE;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_EFFECT_LEVEL;
+	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_STRENGTHEN_INFECTED;
+	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_RESISTANCE_INFECTED;
 	public static ForgeConfigSpec.ConfigValue<Float> CORRUPTION_EFFECT_POWER;
 	public static ForgeConfigSpec.ConfigValue<Double> PARANOIA_MODIFIER;
 	
@@ -43,6 +45,10 @@ public class Config {
 		SERVER_BUILDER.comment("Compat Settings").push("Compat");
 		CALYX_EFFECT_LEVEL = SERVER_BUILDER.comment("The level at which Calyx Infection causes corrupted land to heal instead of poison")
 				.define("Calyx_Level", 60);
+		CALYX_STRENGTHEN_INFECTED = SERVER_BUILDER.comment("Strength Effect level of entities Heavily Infected with Immortuos on corrupted land")
+						.defineInRange("Calyx_Strength", 1, 0, 5);
+		CALYX_RESISTANCE_INFECTED = SERVER_BUILDER.comment("Resistance Effect level of entities Heavily Infected with Immortuos on corrupted land")
+						.defineInRange("Calyx_Resistance", 1, 0, 5);
 		SERVER_BUILDER.pop();
 		
 		COMMON_BUILDER.comment("Compat Settings").push("Compat");

--- a/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
+++ b/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
@@ -76,6 +76,11 @@ public class CorruptedLandMod {
 				BlockPos pos = new BlockPos(event.getEntityItem().getX(), event.getEntityItem().getY()-1, event.getEntityItem().getZ());
 				Core.corruptLand(pos, event.getEntityItem().getServer().getLevel(event.getEntityItem().getCommandSenderWorld().dimension()));
 			}
+			//Immortuos eggs corrupting ground
+			if (calyxCap != null && Config.CALYX_EGGS_CORRUPT_LAND.get() && event.getEntityItem().getItem().sameItem(new ItemStack(Register.IMMORTUOSCALYXEGGS.get()))){
+				BlockPos pos = new BlockPos(event.getEntityItem().getX(), event.getEntityItem().getY()-1, event.getEntityItem().getZ());
+				Core.corruptLand(pos, event.getEntityItem().getServer().getLevel(event.getEntityItem().getCommandSenderWorld().dimension()));
+			}
 		}
 		
 		@SubscribeEvent
@@ -127,6 +132,7 @@ public class CorruptedLandMod {
 						event.getEntityLiving().heal(Config.CORRUPTION_EFFECT_POWER.get());
 					}
 					if(calyxCap != null && event.getEntityLiving() instanceof InfectedEntity && bs.getBlock() instanceof ICorrupted){
+						//Infected entities getting bonus effects if enabled in config.
 						if(Config.CALYX_STRENGTHEN_INFECTED.get() > 0){event.getEntityLiving().addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 5, Config.CALYX_STRENGTHEN_INFECTED.get() - 1, false, false));}
 						if(Config.CALYX_RESISTANCE_INFECTED.get() > 0){event.getEntityLiving().addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 5, Config.CALYX_RESISTANCE_INFECTED.get() - 1, false, false));}
 					}

--- a/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
+++ b/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
@@ -3,6 +3,11 @@ package com.dicemc.corruptedlands;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+
+import com.cartoonishvillain.ImmortuosCalyx.Entity.InfectedEntity;
+import com.cartoonishvillain.ImmortuosCalyx.Register;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import com.dicemc.corruptedlands.blocks.ICorrupted;
@@ -120,6 +125,10 @@ public class CorruptedLandMod {
 					BlockState bs = event.getEntityLiving().getCommandSenderWorld().getBlockState(event.getEntityLiving().blockPosition().below());
 					if (bs.getBlock() instanceof ICorrupted) {
 						event.getEntityLiving().heal(Config.CORRUPTION_EFFECT_POWER.get());
+					}
+					if(calyxCap != null && event.getEntityLiving() instanceof InfectedEntity && bs.getBlock() instanceof ICorrupted){
+						if(Config.CALYX_STRENGTHEN_INFECTED.get() > 0){event.getEntityLiving().addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 5, Config.CALYX_STRENGTHEN_INFECTED.get() - 1, false, false));}
+						if(Config.CALYX_RESISTANCE_INFECTED.get() > 0){event.getEntityLiving().addEffect(new MobEffectInstance(MobEffects.DAMAGE_RESISTANCE, 5, Config.CALYX_RESISTANCE_INFECTED.get() - 1, false, false));}
 					}
 				}
 			}


### PR DESCRIPTION
Got bored and was inspired to add additional functionality to the mod through the compatibility with Immortuos. 

Didn't know how you'd want it versioned if you decided to accept it, so I left that alone.

No worries if you decide it's too much or generally don't want to add this functionality. It was a nice first run on working with someone else's code regardless.

Quick summary of what all was added and changed:

* Updated forge on userdev
* Added in and commented out Implementation in build.gradle. For some reason runtimeOnly wasn't working right for me so Implementation did the trick for testing.
* InfectedEntities get configurable strength and resistance buffs on corrupted grounds.
* Immortuos Calyx eggs can spread corruption (Also configurable)