### PR TITLE
Additional compat and other features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
     }
 }
 
-version = '1.2'
+version = '1.2.1'
 group = 'com.yourname.modid'
 archivesBaseName = 'CorruptedLand'
 
@@ -72,8 +72,8 @@ minecraft {
 dependencies {
     minecraft 'net.minecraftforge:forge:1.17.1-37.0.13'
     //Implementation allows you to have both the in code references, and load the mod in game for testing!
-//    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
-    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+//    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 //    runtimeOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,8 @@ minecraft {
 dependencies {
     minecraft 'net.minecraftforge:forge:1.17.1-37.0.13'
     //Implementation allows you to have both the in code references, and load the mod in game for testing!
-    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
-//    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+//    implementation fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
+    compileOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 //    runtimeOnly fg.deobf("curse.maven:immortuos-calyx-411857:3399714")
 }
 

--- a/src/main/java/com/dicemc/corruptedlands/CommonSetup.java
+++ b/src/main/java/com/dicemc/corruptedlands/CommonSetup.java
@@ -9,6 +9,8 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 @Mod.EventBusSubscriber(modid = CorruptedLandMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class CommonSetup {
@@ -28,17 +30,25 @@ public class CommonSetup {
         }*/
     }
 
-    public static ArrayList<ResourceLocation> getBiomesForResistance() {
+    public static HashMap<ResourceLocation, Integer> getBiomesForResistance() {
         final String BiomeList = Config.BIOMERESIST.get();
+        //split biome-resistance pairs
         String[] Biomeresist = BiomeList.split(",");
-        int resistLength = Biomeresist.length;
-        ArrayList<ResourceLocation> finalBiomeresist = new ArrayList<>();
-        int counter = 0;
-        for (String i : Biomeresist) {
-            ResourceLocation newResource = new ResourceLocation(i);
-            finalBiomeresist.add(newResource);
-            counter++;
+        HashMap<ResourceLocation, Integer> resistanceMap = new HashMap<>();
+        try {
+            for (String string : Biomeresist) {
+                //split the biome-resistance pair
+                    String[] resistanceSplit = string.split(";");
+                    //protects against outofrangeexception from blank entry.
+                    if(resistanceSplit.length == 2) {
+                        ResourceLocation biome = new ResourceLocation(resistanceSplit[0]);
+                        Integer resistance = Integer.valueOf(resistanceSplit[1]);
+                        resistanceMap.put(biome, resistance);
+                    }
+            }
+        }catch (NumberFormatException e){
+            CorruptedLandMod.LOG.error("Corrupted Land: Resistances not parsed! Error in config: Invalid character where a number should be! See format guide in the common config for more information!");
         }
-        return finalBiomeresist;
+        return resistanceMap;
     }
 }

--- a/src/main/java/com/dicemc/corruptedlands/CommonSetup.java
+++ b/src/main/java/com/dicemc/corruptedlands/CommonSetup.java
@@ -1,15 +1,21 @@
 package com.dicemc.corruptedlands;
 
 //import io.github.championash5357.paranoia.api.callback.SanityCallbacks;
+import com.cartoonishvillain.ImmortuosCalyx.ImmortuosCalyx;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraft.world.item.Items;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 
+import java.util.ArrayList;
+
 @Mod.EventBusSubscriber(modid = CorruptedLandMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class CommonSetup {
 	public static void init(final FMLCommonSetupEvent event)
     {
+        CorruptedLandMod.biomeResistance = getBiomesForResistance();
+
 		event.enqueueWork(
             () -> DispenserBlock.registerBehavior(
                 Items.ROTTEN_FLESH,
@@ -20,5 +26,19 @@ public class CommonSetup {
         			player.level.getBlockState(player.blockPosition().below()).getBlock() instanceof ICorrupted);
         	SanityCallbacks.registerMultiplier(pred, Config.PARANOIA_MODIFIER.get());
         }*/
+    }
+
+    public static ArrayList<ResourceLocation> getBiomesForResistance() {
+        final String BiomeList = Config.BIOMERESIST.get();
+        String[] Biomeresist = BiomeList.split(",");
+        int resistLength = Biomeresist.length;
+        ArrayList<ResourceLocation> finalBiomeresist = new ArrayList<>();
+        int counter = 0;
+        for (String i : Biomeresist) {
+            ResourceLocation newResource = new ResourceLocation(i);
+            finalBiomeresist.add(newResource);
+            counter++;
+        }
+        return finalBiomeresist;
     }
 }

--- a/src/main/java/com/dicemc/corruptedlands/Config.java
+++ b/src/main/java/com/dicemc/corruptedlands/Config.java
@@ -17,6 +17,7 @@ public class Config {
 	public static ForgeConfigSpec.ConfigValue<Boolean> CALYX_EGGS_CORRUPT_LAND;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_STRENGTHEN_INFECTED;
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_RESISTANCE_INFECTED;
+	public static ForgeConfigSpec.ConfigValue<Boolean> CALYX_HARMED_BY_PURIFIER;
 	public static ForgeConfigSpec.ConfigValue<Float> CORRUPTION_EFFECT_POWER;
 	public static ForgeConfigSpec.ConfigValue<Double> PARANOIA_MODIFIER;
 	
@@ -52,6 +53,7 @@ public class Config {
 						.defineInRange("Calyx_Resistance", 1, 0, 5);
 		CALYX_EGGS_CORRUPT_LAND = SERVER_BUILDER.comment("Whether or not Immortuos Calyx eggs will corrupt land along with rotten flesh.")
 						.define("Calyx_Eggs_Corrupt", true);
+		CALYX_HARMED_BY_PURIFIER = SERVER_BUILDER.comment("Whether or not entities heavily infected by Immortuos Calyx are harmed by the use of a purifier nearby.").define("Calyx_Harmed_By_Purifier", true);
 		SERVER_BUILDER.pop();
 		
 		COMMON_BUILDER.comment("Compat Settings").push("Compat");

--- a/src/main/java/com/dicemc/corruptedlands/Config.java
+++ b/src/main/java/com/dicemc/corruptedlands/Config.java
@@ -19,6 +19,8 @@ public class Config {
 	public static ForgeConfigSpec.ConfigValue<Integer> CALYX_RESISTANCE_INFECTED;
 	public static ForgeConfigSpec.ConfigValue<Boolean> CALYX_HARMED_BY_PURIFIER;
 	public static ForgeConfigSpec.ConfigValue<Float> CORRUPTION_EFFECT_POWER;
+	public static ForgeConfigSpec.ConfigValue<String> BIOMERESIST;
+	public static ForgeConfigSpec.ConfigValue<Integer> BIOMERESISTAMOUNT;
 	public static ForgeConfigSpec.ConfigValue<Double> PARANOIA_MODIFIER;
 	
 	static {
@@ -55,9 +57,17 @@ public class Config {
 						.define("Calyx_Eggs_Corrupt", true);
 		CALYX_HARMED_BY_PURIFIER = SERVER_BUILDER.comment("Whether or not entities heavily infected by Immortuos Calyx are harmed by the use of a purifier nearby.").define("Calyx_Harmed_By_Purifier", true);
 		SERVER_BUILDER.pop();
-		
-		COMMON_BUILDER.comment("Compat Settings").push("Compat");
-		PARANOIA_MODIFIER = SERVER_BUILDER.comment("value between -1 and 1 to define the rate at which corrupted land impacts paranoia.")
+
+		COMMON_BUILDER.comment("Common Mod Settings").push("Common");
+		BIOMERESIST = COMMON_BUILDER.comment("EXPERIMENTAL! MUST BE ALL CHARACTERS FROM [a-z0-9/._-] OR THE GAME WILL CRASH. List the biome names seperated by commas that you want to increase the resistance to the corruption of. (eg: minecraft:sunflower_plains,minecraft:flower_forest)")
+						.define("Corruption_Biome_Resistance", "");
+		BIOMERESISTAMOUNT = COMMON_BUILDER.comment("Value between 0 and 100 to define how likely a corruption resistant biome is to stop the spread of corruption on any given attempt.")
+						.defineInRange("Corruption_Resistance_Amount", 20, 0, 100);
+		COMMON_BUILDER.pop();
+
+		//Changed this to common since it's under Common Builder.
+		COMMON_BUILDER.comment("Common Compat Settings").push("Compat");
+		PARANOIA_MODIFIER = COMMON_BUILDER.comment("value between -1 and 1 to define the rate at which corrupted land impacts paranoia.")
 				.defineInRange("Paranoia_Modifier", 0.001, -1d, 1d);
 		COMMON_BUILDER.pop();
 		

--- a/src/main/java/com/dicemc/corruptedlands/Config.java
+++ b/src/main/java/com/dicemc/corruptedlands/Config.java
@@ -20,7 +20,6 @@ public class Config {
 	public static ForgeConfigSpec.ConfigValue<Boolean> CALYX_HARMED_BY_PURIFIER;
 	public static ForgeConfigSpec.ConfigValue<Float> CORRUPTION_EFFECT_POWER;
 	public static ForgeConfigSpec.ConfigValue<String> BIOMERESIST;
-	public static ForgeConfigSpec.ConfigValue<Integer> BIOMERESISTAMOUNT;
 	public static ForgeConfigSpec.ConfigValue<Double> PARANOIA_MODIFIER;
 	
 	static {
@@ -59,10 +58,8 @@ public class Config {
 		SERVER_BUILDER.pop();
 
 		COMMON_BUILDER.comment("Common Mod Settings").push("Common");
-		BIOMERESIST = COMMON_BUILDER.comment("EXPERIMENTAL! MUST BE ALL CHARACTERS FROM [a-z0-9/._-] OR THE GAME WILL CRASH. List the biome names seperated by commas that you want to increase the resistance to the corruption of. (eg: minecraft:sunflower_plains,minecraft:flower_forest)")
+		BIOMERESIST = COMMON_BUILDER.comment("BIOME NAMES MUST BE ALL CHARACTERS FROM [a-z0-9/._-] OR THE GAME WILL CRASH. List biomes and their resistance values seperated by a semi colon (;), with each biome seperated by a comma (,). Example: \"minecraft:sunflower_plains;40,minecraft:flower_forest;20\"")
 						.define("Corruption_Biome_Resistance", "");
-		BIOMERESISTAMOUNT = COMMON_BUILDER.comment("Value between 0 and 100 to define how likely a corruption resistant biome is to stop the spread of corruption on any given attempt.")
-						.defineInRange("Corruption_Resistance_Amount", 20, 0, 100);
 		COMMON_BUILDER.pop();
 
 		//Changed this to common since it's under Common Builder.

--- a/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
+++ b/src/main/java/com/dicemc/corruptedlands/CorruptedLandMod.java
@@ -59,7 +59,7 @@ public class CorruptedLandMod {
 	public static MinecraftServer SERVER;
 	public static Map<Block, Block> corruptionPair = new HashMap<Block, Block>();
 	public static Capability<?> calyxCap = null;
-	public static ArrayList<ResourceLocation> biomeResistance;
+	public static HashMap<ResourceLocation, Integer> biomeResistance;
 
 	public CorruptedLandMod() {
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.COMMON_CONFIG);
@@ -167,8 +167,8 @@ public class CorruptedLandMod {
 			//pre-emptive boolean
 			boolean resisted = false;
 			// if Biome resistance is set for 0, no need to continue this check. Otherwise check if the current biome is in the list of resistant biomes.
-			if(Config.BIOMERESISTAMOUNT.get() > 0 && biomeResistance.contains(serverWorld.getBiome(pos).getRegistryName())) {
-				int chanceToResist = Config.BIOMERESISTAMOUNT.get();
+			if(biomeResistance.containsKey(serverWorld.getBiome(pos).getRegistryName())) {
+				int chanceToResist = biomeResistance.get(serverWorld.getBiome(pos).getRegistryName());
 				if(serverWorld.random.nextInt(100) <= chanceToResist) resisted = true;
 			}
 			//if the resistance check resulted in no resistance, continue as normal. Otherwise if resistance is successful, cancel the spread this time.

--- a/src/main/java/com/dicemc/corruptedlands/items/PurifierItem.java
+++ b/src/main/java/com/dicemc/corruptedlands/items/PurifierItem.java
@@ -1,8 +1,19 @@
 package com.dicemc.corruptedlands.items;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.cartoonishvillain.ImmortuosCalyx.Entity.InfectedEntity;
+import com.cartoonishvillain.ImmortuosCalyx.Infection.InfectionManagerCapability;
+import com.cartoonishvillain.ImmortuosCalyx.InternalOrganDamage;
 import com.dicemc.corruptedlands.Config;
+import com.dicemc.corruptedlands.CorruptedLandMod;
 import com.dicemc.corruptedlands.blocks.ICorrupted;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.Blocks;
@@ -50,6 +61,33 @@ public class PurifierItem extends Item{
 						}
 					}
 				}	
+			}
+			//Purifier used within range of Infected entities can harm and debuff
+			if(CorruptedLandMod.calyxCap != null && Config.CALYX_HARMED_BY_PURIFIER.get()){
+				//increases radius a bit
+				box.setMaxY(box.maxY + 3);
+				box.setMinY(box.minY - 3);
+				box.setMaxX(box.maxX + 3);
+				box.setMinX(box.minX - 3);
+				box.setMaxZ(box.maxZ + 3);
+				box.setMinZ(box.minZ - 3);
+				ArrayList<Entity> entities = (ArrayList<Entity>) context.getLevel().getEntities(null, box);
+				ArrayList<LivingEntity> LivingEntities = new ArrayList<>();
+				//Grab all suitably infected entities.
+				for(Entity entity : entities){
+					if(entity instanceof InfectedEntity) LivingEntities.add((LivingEntity) entity);
+					else if (entity instanceof LivingEntity){
+						AtomicInteger infectionRate = new AtomicInteger(0);
+						entity.getCapability(InfectionManagerCapability.INSTANCE).ifPresent(h->{infectionRate.set(h.getInfectionProgress());});
+						if(infectionRate.get() >= Config.CALYX_EFFECT_LEVEL.get()) LivingEntities.add((LivingEntity) entity);
+					}
+				}
+				//Negatively Effect them.
+				for(LivingEntity livingEntity : LivingEntities){
+					livingEntity.hurt(InternalOrganDamage.causeInternalDamage(livingEntity), (livingEntity.getMaxHealth()/5));
+					livingEntity.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, 90*20, 1, true, true));
+					livingEntity.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 90*20, 1, true, true));
+				}
 			}
 			return InteractionResult.SUCCESS;
 		}


### PR DESCRIPTION
I return with more features for you to decide if you want to add or not.

New features:

* Configurable feature: Heavily infected entities can be harmed by the use of purifiers nearby. This also applies slowness and blindness.

* Certain biomes can now configurably resist being corrupted more than others. If the biome is included in the list of resistant biomes, the corruption must roll higher than the resistance rate on a random bound to 100.